### PR TITLE
Fixed texture dir splitting on Windows, added lightmap dir search, added hide menu

### DIFF
--- a/kotorblender/__init__.py
+++ b/kotorblender/__init__.py
@@ -27,6 +27,19 @@ from .ops.anim.move import KB_OT_move_animation
 from .ops.anim.play import KB_OT_play_animation
 from .ops.assignnodenumbers import KB_OT_assign_node_numbers
 from .ops.bakelightmaps import KB_OT_bake_lightmaps
+from .ops.hideobjects import (
+    KB_OT_hide_walkmeshes,
+    KB_OT_hide_lights,
+    KB_OT_hide_blockers,
+    KB_OT_hide_charbones,
+    KB_OT_hide_charnulls,
+    KB_OT_unhide_walkmeshes,
+    KB_OT_unhide_lights,
+    KB_OT_unhide_blockers,
+    KB_OT_unhide_charbones,
+    KB_OT_unhide_charnulls,
+    KB_OT_unhide_all
+)
 from .ops.lensflare.add import KB_OT_add_lens_flare
 from .ops.lensflare.delete import KB_OT_delete_lens_flare
 from .ops.lensflare.move import KB_OT_move_lens_flare
@@ -50,6 +63,7 @@ from .props.pathconnection import PathConnectionPropertyGroup
 from .props.scene import ScenePropertyGroup
 from .ui.list.lensflares import KB_UL_lens_flares
 from .ui.list.pathpoints import KB_UL_path_points
+from .ui.menu.hideobjectsmenu import KB_MT_hide_menu
 from .ui.panel.animations import KB_PT_animations, KB_PT_anim_events
 from .ui.panel.lightmaps import KB_PT_lightmaps
 from .ui.panel.modelnode.emitter import (
@@ -82,7 +96,6 @@ bl_info = {
     "description": "Import, edit and export KotOR models",
     "category": "Import-Export"}
 
-
 def menu_func_import_mdl(self, context):
     self.layout.operator(KB_OT_import_mdl.bl_idname, text="KotOR Model (.mdl)")
 
@@ -105,6 +118,10 @@ def menu_func_export_lyt(self, context):
 
 def menu_func_export_pth(self, context):
     self.layout.operator(KB_OT_export_pth.bl_idname, text="KotOR Path (.pth)")
+
+
+def menu_func_hide_wlk(self, context):
+    self.layout.menu("KB_MT_hide_menu")
 
 
 classes = (
@@ -148,6 +165,18 @@ classes = (
     KB_OT_delete_path_connection,
 
     KB_OT_bake_lightmaps,
+    
+    KB_OT_hide_walkmeshes,
+    KB_OT_hide_lights,
+    KB_OT_hide_blockers,
+    KB_OT_hide_charbones,
+    KB_OT_hide_charnulls,
+    KB_OT_unhide_walkmeshes,
+    KB_OT_unhide_lights,
+    KB_OT_unhide_blockers,
+    KB_OT_unhide_charbones,
+    KB_OT_unhide_charnulls,
+    KB_OT_unhide_all,
 
     # Panels
 
@@ -182,7 +211,11 @@ classes = (
     # UI Lists
 
     KB_UL_lens_flares,
-    KB_UL_path_points
+    KB_UL_path_points,
+    
+    # Menus
+    
+    KB_MT_hide_menu
 )
 
 
@@ -200,6 +233,8 @@ def register():
     bpy.types.TOPBAR_MT_file_export.append(menu_func_export_lyt)
     bpy.types.TOPBAR_MT_file_export.append(menu_func_export_pth)
 
+    bpy.types.TOPBAR_MT_editor_menus.append(menu_func_hide_wlk)
+
 
 def unregister():
     bpy.types.TOPBAR_MT_file_export.remove(menu_func_export_pth)
@@ -208,6 +243,8 @@ def unregister():
     bpy.types.TOPBAR_MT_file_import.remove(menu_func_import_pth)
     bpy.types.TOPBAR_MT_file_import.remove(menu_func_import_lyt)
     bpy.types.TOPBAR_MT_file_import.remove(menu_func_import_mdl)
+
+    bpy.types.TOPBAR_MT_editor_menus.remove(menu_func_hide_wlk)
 
     for cls in classes:
         bpy.utils.unregister_class(cls)

--- a/kotorblender/defines.py
+++ b/kotorblender/defines.py
@@ -151,6 +151,7 @@ class ImportOptions:
         self.normals_algorithm = NormalsAlgorithm.CUSTOM
         self.sharp_edge_angle = radians(10.0)
         self.texture_search_paths = []
+        self.lightmap_search_paths = []
 
 
 class ExportOptions:

--- a/kotorblender/ops/hideobjects.py
+++ b/kotorblender/ops/hideobjects.py
@@ -1,0 +1,216 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import bpy
+
+from ..ui.menu.bonelistchar import CharBoneNames
+from ..ui.menu.dummylistchar import CharDummyNames
+from ..defines import MeshType, DummyType
+from .. import utils
+
+class KB_OT_hide_walkmeshes(bpy.types.Operator):
+    bl_idname = "kb.hide_walkmeshes"
+    bl_label = "Hide Walkmeshes"
+    bl_description = 'Hides all walkmeshes in the scene'
+    
+    def execute(self, context):
+        #Deselect everything in the scene first.
+        bpy.ops.object.select_all(action='DESELECT')
+        
+        #Loop through every object in the scene and hide it if it's a walkmesh.
+        for obj in bpy.context.scene.objects:
+            if utils.is_mesh_type(obj, MeshType.AABB) or utils.is_dwk_root(obj) or utils.is_pwk_root(obj):
+                obj.hide_set(True)
+        
+        return {'FINISHED'}
+
+
+class KB_OT_hide_lights(bpy.types.Operator):
+    bl_idname = "kb.hide_lights"
+    bl_label = "Hide Lights"
+    bl_description = 'Hides all lights in the scene'
+    
+    def execute(self, context):
+        #Deselect everything in the scene first.
+        bpy.ops.object.select_all(action='DESELECT')
+        
+        #Loop through every object in the scene and hide it if it's a light.
+        for obj in bpy.context.scene.objects:
+            if obj.type == 'LIGHT':
+                obj.hide_set(True)
+        
+        return {'FINISHED'}
+
+
+class KB_OT_hide_blockers(bpy.types.Operator):
+    bl_idname = "kb.hide_blockers"
+    bl_label = "Hide Blockers"
+    bl_description = 'Hides all untextured blocker trimeshes in the scene'
+    
+    def execute(self, context):
+        #Deselect everything in the scene first.
+        bpy.ops.object.select_all(action='DESELECT')
+        
+        #Loop through every object in the scene and hide it if it's an untextured trimesh.
+        for obj in bpy.context.scene.objects:
+            if utils.is_mesh_type(obj, MeshType.TRIMESH) and not utils.is_skin_mesh(obj) and obj.kb.render == 1:
+                if utils.is_null(obj.kb.bitmap) and utils.is_null(obj.kb.bitmap2):
+                    obj.hide_set(True)
+        
+        return {'FINISHED'}
+
+
+class KB_OT_hide_charbones(bpy.types.Operator):
+    bl_idname = "kb.hide_charbones"
+    bl_label = "Hide Character Bones"
+    bl_description = 'Hides all humanoid rig bones in the scene'
+    
+    def execute(self, context):
+        #Deselect everything in the scene first.
+        bpy.ops.object.select_all(action='DESELECT')
+        
+        #Loop through every object in the scene and hide it if it's a bone matching the name of those in a character rig.
+        for obj in bpy.context.scene.objects:
+            if utils.is_mesh_type(obj, MeshType.TRIMESH) and not utils.is_skin_mesh(obj) and obj.kb.render == 0:
+                if obj.name.lower() in CharBoneNames:
+                    obj.hide_set(True)
+        
+        return {'FINISHED'}
+
+
+class KB_OT_hide_charnulls(bpy.types.Operator):
+    bl_idname = "kb.hide_charnulls"
+    bl_label = "Hide Character Dummies"
+    bl_description = 'Hides all humanoid rig dummy/null objects in the scene'
+    
+    def execute(self, context):
+        #Deselect everything in the scene first.
+        bpy.ops.object.select_all(action='DESELECT')
+        
+        #Loop through every object in the scene and hide it if it's a dummy/null matching the name of those in a character rig.
+        for obj in bpy.context.scene.objects:
+            if utils.is_dummy_type(obj, DummyType.NONE):
+                if obj.name.lower() in CharDummyNames:
+                    obj.hide_set(True)
+        
+        return {'FINISHED'}
+
+
+class KB_OT_unhide_walkmeshes(bpy.types.Operator):
+    bl_idname = "kb.unhide_walkmeshes"
+    bl_label = "Unhide Walkmeshes"
+    bl_description = 'Unhides all walkmeshes in the scene'
+    
+    def execute(self, context):
+        #Deselect everything in the scene first.
+        bpy.ops.object.select_all(action='DESELECT')
+        
+        #Loop through every object in the scene and unhide it if it's a walkmesh.
+        for obj in bpy.context.scene.objects:
+            if utils.is_mesh_type(obj, MeshType.AABB) or utils.is_dwk_root(obj) or utils.is_pwk_root(obj):
+                obj.hide_set(False)
+        
+        return {'FINISHED'}
+
+
+class KB_OT_unhide_lights(bpy.types.Operator):
+    bl_idname = "kb.unhide_lights"
+    bl_label = "Unhide Lights"
+    bl_description = 'Unhides all lights in the scene'
+    
+    def execute(self, context):
+        #Deselect everything in the scene first.
+        bpy.ops.object.select_all(action='DESELECT')
+        
+        #Loop through every object in the scene and unhide it if it's a light.
+        for obj in bpy.context.scene.objects:
+            if obj.type == 'LIGHT':
+                obj.hide_set(False)
+        
+        return {'FINISHED'}
+
+
+class KB_OT_unhide_blockers(bpy.types.Operator):
+    bl_idname = "kb.unhide_blockers"
+    bl_label = "Unhide Blockers"
+    bl_description = 'Unhides all untextured blocker trimeshes in the scene'
+    
+    def execute(self, context):
+        #Deselect everything in the scene first.
+        bpy.ops.object.select_all(action='DESELECT')
+        
+        #Loop through every object in the scene and unhide it if it's an untextured trimesh.
+        for obj in bpy.context.scene.objects:
+            if utils.is_mesh_type(obj, MeshType.TRIMESH) and not utils.is_skin_mesh(obj) and obj.kb.render == 1:
+                if utils.is_null(obj.kb.bitmap) and utils.is_null(obj.kb.bitmap2):
+                    obj.hide_set(False)
+        
+        return {'FINISHED'}
+
+
+class KB_OT_unhide_charbones(bpy.types.Operator):
+    bl_idname = "kb.unhide_charbones"
+    bl_label = "Unhide Character Bones"
+    bl_description = 'Unhides all humanoid rig bones in the scene'
+    
+    def execute(self, context):
+        #Deselect everything in the scene first.
+        bpy.ops.object.select_all(action='DESELECT')
+        
+        #Loop through every object in the scene and unhide it if it's a bone matching the name of those in a character rig.
+        for obj in bpy.context.scene.objects:
+            if utils.is_mesh_type(obj, MeshType.TRIMESH) and not utils.is_skin_mesh(obj) and obj.kb.render == 0:
+                if obj.name.lower() in CharBoneNames:
+                    obj.hide_set(False)
+        
+        return {'FINISHED'}
+
+
+class KB_OT_unhide_charnulls(bpy.types.Operator):
+    bl_idname = "kb.unhide_charnulls"
+    bl_label = "Unhide Character Dummies"
+    bl_description = 'Unhides all humanoid rig dummy/null objects in the scene'
+    
+    def execute(self, context):
+        #Deselect everything in the scene first.
+        bpy.ops.object.select_all(action='DESELECT')
+        
+        #Loop through every object in the scene and unhide it if it's a dummy/null matching the name of those in a character rig.
+        for obj in bpy.context.scene.objects:
+            if utils.is_dummy_type(obj, DummyType.NONE):
+                if obj.name.lower() in CharDummyNames:
+                    obj.hide_set(False)
+        
+        return {'FINISHED'}
+
+
+class KB_OT_unhide_all(bpy.types.Operator):
+    bl_idname = "kb.unhide_all"
+    bl_label = "Unhide All Objects"
+    bl_description = 'Unhides all objects in the scene'
+    
+    def execute(self, context):
+        #Deselect everything in the scene first.
+        bpy.ops.object.select_all(action='DESELECT')
+        
+        #Loop through every object in the scene and unhide it.
+        for obj in bpy.context.scene.objects:
+            obj.hide_viewport = False
+            obj.hide_set(False)
+        
+        return {'FINISHED'}

--- a/kotorblender/ops/lyt/importop.py
+++ b/kotorblender/ops/lyt/importop.py
@@ -72,7 +72,12 @@ class KB_OT_import_lyt(bpy.types.Operator, ImportHelper):
 
     texture_search_paths: bpy.props.StringProperty(
         name="Texture Search Paths",
-        description="Colon-separated list of paths relative to imported layout",
+        description="Semi-colon-separated list of paths. Can be relative to the imported layout or absolute.",
+        default="../texturepacks/swpc_tex_tpa")
+
+    lightmap_search_paths: bpy.props.StringProperty(
+        name="Lightmap Search Paths",
+        description="Semi-colon-separated list of paths. Can be relative to the imported layout or absolute.",
         default="../texturepacks/swpc_tex_tpa")
 
     def execute(self, context):
@@ -83,6 +88,7 @@ class KB_OT_import_lyt(bpy.types.Operator, ImportHelper):
         options.normals_algorithm = self.normals_algorithm
         options.sharp_edge_angle = self.sharp_edge_angle
         options.texture_search_paths = self.colon_separated_paths_to_absolute_paths(self.texture_search_paths, os.path.dirname(self.filepath))
+        options.lightmap_search_paths = self.colon_separated_paths_to_absolute_paths(self.lightmap_search_paths, os.path.dirname(self.filepath))
 
         try:
             lyt.load_lyt(self, self.filepath, options)
@@ -94,7 +100,7 @@ class KB_OT_import_lyt(bpy.types.Operator, ImportHelper):
 
     def colon_separated_paths_to_absolute_paths(self, paths_str, working_dir):
         abs_paths = []
-        rel_paths = paths_str.split(":")
+        rel_paths = paths_str.split(";")
         for rel_path in rel_paths:
             abs_path = rel_path if os.path.isabs(rel_path) else os.path.join(working_dir, rel_path)
             abs_paths.append(abs_path)

--- a/kotorblender/ops/mdl/importop.py
+++ b/kotorblender/ops/mdl/importop.py
@@ -82,7 +82,12 @@ class KB_OT_import_mdl(bpy.types.Operator, ImportHelper):
 
     texture_search_paths: bpy.props.StringProperty(
         name="Texture Search Paths",
-        description="Colon-separated list of paths relative to imported model",
+        description="Semi-colon-separated list of paths. Can be relative to the imported model or absolute.",
+        default="../texturepacks/swpc_tex_tpa")
+
+    lightmap_search_paths: bpy.props.StringProperty(
+        name="Lightmap Search Paths",
+        description="Semi-colon-separated list of paths. Can be relative to the imported model or absolute.",
         default="../texturepacks/swpc_tex_tpa")
 
     def execute(self, context):
@@ -95,6 +100,7 @@ class KB_OT_import_mdl(bpy.types.Operator, ImportHelper):
         options.normals_algorithm = self.normals_algorithm
         options.sharp_edge_angle = self.sharp_edge_angle
         options.texture_search_paths = self.colon_separated_paths_to_absolute_paths(self.texture_search_paths, os.path.dirname(self.filepath))
+        options.lightmap_search_paths = self.colon_separated_paths_to_absolute_paths(self.lightmap_search_paths, os.path.dirname(self.filepath))
 
         try:
             mdl.load_mdl(self, self.filepath, options)
@@ -106,7 +112,7 @@ class KB_OT_import_mdl(bpy.types.Operator, ImportHelper):
 
     def colon_separated_paths_to_absolute_paths(self, paths_str, working_dir):
         abs_paths = []
-        rel_paths = paths_str.split(":")
+        rel_paths = paths_str.split(";")
         for rel_path in rel_paths:
             abs_path = rel_path if os.path.isabs(rel_path) else os.path.join(working_dir, rel_path)
             abs_paths.append(abs_path)

--- a/kotorblender/scene/modelnode/trimesh.py
+++ b/kotorblender/scene/modelnode/trimesh.py
@@ -102,7 +102,7 @@ class TrimeshNode(GeometryNode):
         self.set_object_data(obj, options)
 
         if options.build_materials and self.roottype == RootType.MODEL:
-            material.rebuild_object_material(obj, options.texture_search_paths)
+            material.rebuild_object_material(obj, options.texture_search_paths, options.lightmap_search_paths)
 
         collection.objects.link(obj)
         return obj

--- a/kotorblender/ui/menu/bonelistchar.py
+++ b/kotorblender/ui/menu/bonelistchar.py
@@ -1,0 +1,99 @@
+# ##### begin gpl license block #####
+#
+#  this program is free software; you can redistribute it and/or
+#  modify it under the terms of the gnu general public license
+#  as published by the free software foundation; either version 2
+#  of the license, or (at your option) any later version.
+#
+#  this program is distributed in the hope that it will be useful,
+#  but without any warranty; without even the implied warranty of
+#  merchantability or fitness for a particular purpose.  see the
+#  gnu general public license for more details.
+#
+#  you should have received a copy of the gnu general public license
+#  along with this program; if not, write to the free software foundation,
+#  inc., 51 franklin street, fifth floor, boston, ma 02110-1301, usa.
+#
+# ##### end gpl license block #####
+
+# A list of trimesh bones used in human character rigs (male and female) in both games.
+# Used for the hide/unhide menu functions. Store in lowercase.
+
+CharBoneNames = [
+    "breastbone",
+    "f_jaw_g",
+    "f_lbrw_g",
+    "f_llm_g",
+    "f_llweye_g",
+    "f_lmc_g",
+    "f_lns_g",
+    "f_mdbrw_g",
+    "f_rbrw_g",
+    "f_rlm_g",
+    "f_rlweye_g",
+    "f_rmc_g",
+    "f_rns_g",
+    "f_tonguetip_g",
+    "f_um_g",
+    "frobe1_g",
+    "frobe2_g",
+    "head_g",
+    "lafngrb_g",
+    "lafngrt_g",
+    "lbfngrb_g",
+    "lbfngrt_g",
+    "lbicep_g",
+    "lbicep_gl",
+    "lbicepl_g",
+    "lcfngrb_g",
+    "lcfngrt_g",
+    "lcollar_g",
+    "ldfngrb_g",
+    "ldfngrt_g",
+    "lfoot_g",
+    "lfoott_g",
+    "lforearm_g",
+    "lhand_g",
+    "lrobe1_g",
+    "lrobe2_g",
+    "lrobe3_g",
+    "lshin_g",
+    "lsleeve1_g",
+    "lsleeve2_g",
+    "lthigh_g",
+    "lthumbb_g",
+    "lthumbt_g",
+    "mrobe1_g",
+    "mrobe2_g",
+    "mrobe3_g",
+    "neck_g",
+    "necklwr_g",
+    "pelvis_g",
+    "rafngrb_g",
+    "rafngrt_g",
+    "rbfngrb_g",
+    "rbfngrt_g",
+    "rbicep_g",
+    "rbicep_gl",
+    "rbicepl_g",
+    "rcfngrb_g",
+    "rcfngrt_g",
+    "rcollar_g",
+    "rdfngrb_g",
+    "rdfngrt_g",
+    "rfoot_g",
+    "rfoott_g",
+    "rforearm_g",
+    "rhand_g",
+    "rrobe1_g",
+    "rrobe2_g",
+    "rrobe3_g",
+    "rshin_g",
+    "rsleeve1_g",
+    "rsleeve2_g",
+    "rthigh_g",
+    "rthumbb_g",
+    "rthumbt_g",
+    "torsoupr_g",
+    "torso_g"
+]

--- a/kotorblender/ui/menu/dummylistchar.py
+++ b/kotorblender/ui/menu/dummylistchar.py
@@ -1,0 +1,48 @@
+# ##### begin gpl license block #####
+#
+#  this program is free software; you can redistribute it and/or
+#  modify it under the terms of the gnu general public license
+#  as published by the free software foundation; either version 2
+#  of the license, or (at your option) any later version.
+#
+#  this program is distributed in the hope that it will be useful,
+#  but without any warranty; without even the implied warranty of
+#  merchantability or fitness for a particular purpose.  see the
+#  gnu general public license for more details.
+#
+#  you should have received a copy of the gnu general public license
+#  along with this program; if not, write to the free software foundation,
+#  inc., 51 franklin street, fifth floor, boston, ma 02110-1301, usa.
+#
+# ##### end gpl license block #####
+
+# A list of dummy/null objects used in human character rigs (male and female) in both games.
+# Used for the hide/unhide menu functions. Store in lowercase.
+
+CharDummyNames = [
+    "camerahook",
+    "cutscenedummy",
+    "deflecthook",
+    "dummy01",
+    "dummy02",
+    "freelookhook",
+    "gogglehook",
+    "handconjure",
+    "headconjure",
+    "headhook",
+    "hturn_g",
+    "hturn_g",
+    "impact",
+    "impact_bolt",
+    "lcollar_dum",
+    "lforearm",
+    "lhand",
+    "lightsaberhook",
+    "maskhook",
+    "rcollar_dum",
+    "revmask1hook",
+    "revmask2hook",
+    "rhand",
+    "rootdummy",
+    "talkdummy"
+]

--- a/kotorblender/ui/menu/hideobjectsmenu.py
+++ b/kotorblender/ui/menu/hideobjectsmenu.py
@@ -1,0 +1,41 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+import bpy
+
+class KB_MT_hide_menu(bpy.types.Menu):
+    bl_label = "KBlender"
+
+    def draw(self, context):
+        layout = self.layout
+        
+        layout.operator("kb.hide_walkmeshes", icon='SURFACE_DATA')
+        layout.operator("kb.hide_lights", icon='LIGHT')
+        layout.operator("kb.hide_blockers", icon='INDIRECT_ONLY_OFF')
+        layout.separator()
+        layout.operator("kb.hide_charbones", icon='BONE_DATA')
+        layout.operator("kb.hide_charnulls", icon='SHADING_BBOX')
+        layout.separator()
+        layout.operator("kb.unhide_walkmeshes", icon='OUTLINER_OB_SURFACE')
+        layout.operator("kb.unhide_lights", icon='OUTLINER_OB_LIGHT')
+        layout.operator("kb.unhide_blockers", icon='INDIRECT_ONLY_ON')
+        layout.separator()
+        layout.operator("kb.unhide_charbones", icon='BONE_DATA')
+        layout.operator("kb.unhide_charnulls", icon='PIVOT_BOUNDBOX')
+        layout.separator()
+        layout.operator("kb.unhide_all")


### PR DESCRIPTION
* Switched splitting of texture folders from colon to semi-colon, since absolute paths would break on Windows.
* Broke out lightmap texture searches to a separate folder input field
* Added a new menu with show/hide functionality for KOTOR-specific objects (walkmeshes, etc.)